### PR TITLE
Test against PHP 8.1. nightly build

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,10 +12,12 @@ jobs:
 
     strategy:
       matrix:
+        # https://github.com/shivammathur/setup-php#tada-php-support
         php-versions:
         - '7.3'
         - '7.4'
-        - '8.0' 
+        - '8.0'
+        - '8.1'
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Fails with:

```
php            8.1.0-dev  phpspec/prophecy requires php (^7.2 || ~8.0, <8.1)  failed   
```