### PR TITLE
PackageInfo: improve the package signature "swapping" logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor/
 composer.phar
 *.swp
+.idea
 
 .coverage.xml
 .coverage/

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "keywords": ["parser", "electronic-components", "electronics-engineering", "integrated-circuits", "elecena"],
     "type": "library",
     "require": {
-      "php": ">=8.1"
+      "php": ">=8.1",
+      "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "10.x"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ab1380a3e895fa042dcb6bfd3cc95cd",
+    "content-hash": "8cbc45690a8e15394244c936ad145731",
     "packages": [],
     "packages-dev": [
         {
@@ -1646,7 +1646,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": ">=8.1",
+        "ext-mbstring": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/src/Elecena/Utils/PackageInfo.php
+++ b/src/Elecena/Utils/PackageInfo.php
@@ -23,7 +23,7 @@ class PackageInfo {
 	 * @param string $desc
 	 * @return string|false
 	 */
-	public static function getPackage($desc) {
+	public static function getPackage(string $desc): bool|string {
 		$package = false;
 		$desc = mb_strtoupper($desc);
 
@@ -37,7 +37,10 @@ class PackageInfo {
 		$desc = preg_replace('#(\d+) LD ([A-Z]+)#', '$1-$2', $desc);
 
 		// "swap" package signatures / 64-LQFP -> LQFP64
-		$desc = preg_replace('#(\d{1,})-\s?([2A-Z]{3,})#', '$2$1', $desc);
+		$desc = preg_replace('#(\d+)-\s?([2A-Z]{3,})#', '$2$1', $desc);
+
+		// "swap" package signatures / 14SOIC -> SOIC14
+		$desc = preg_replace('#\s(\d+)([2A-Z]{3,})#', ' $2$1', $desc);
 
 		// DIP 6 -> DIP-6
 		$desc = preg_replace('#(\b(DIP|ZIP))\s([1-9]\d?)#', '$1-$3', $desc);
@@ -167,7 +170,7 @@ class PackageInfo {
 			// for normalization
 			'SC-?67',
 		];
-		$pattern = '#(^|-|,|:|\s|$|\[|\(|/)(' . join('|', $groups) . ')(\)|\]|;|,|=|\s|/|$)#';
+		$pattern = '#(^|-|,|:|\s|$|\[|\(|/)(' . join('|', $groups) . ')(\)|]|;|,|=|\s|/|$)#';
 
 		if (preg_match(
 			$pattern,
@@ -315,9 +318,9 @@ class PackageInfo {
 				$package = $normalizations[$package];
 			}
 		}
-		else {
-			# var_dump(__METHOD__, $desc, $package); // debug
-		}
+//		else {
+//			var_dump(__METHOD__, $desc, $package); // debug
+//		}
 		return $package;
 	}
 }

--- a/tests/PackageInfoTest.php
+++ b/tests/PackageInfoTest.php
@@ -441,6 +441,9 @@ class PackageInfoTest extends TestCase {
 			[ '16-TSSOP', 'TSSOP16' ],
 			[ '144-LQFP', 'LQFP144' ],
 			[ '64-LQFP', 'LQFP64' ],
+			// https://github.com/elecena/ic-package-info/issues/58
+			[ 'IC BUF NON-INVERT 5.25V SOIC14', 'SOIC14' ],
+			[ 'IC BUF NON-INVERT 5.25V 14SOIC', 'SOIC14' ],
 
 			// normalize packages
 			[ '64-LQFP (10x10)', 'LQFP64' ], // https://elecena.pl/product/7840023/atsam3n1bb-aur (DigiKey)


### PR DESCRIPTION
Resolves #58.

Handle both `IC BUF NON-INVERT 5.25V SOIC14` and `IC BUF NON-INVERT 5.25V 14SOIC`