### PR TITLE
Support Small Outline Diode packages

### DIFF
--- a/src/Elecena/Utils/PackageInfo.php
+++ b/src/Elecena/Utils/PackageInfo.php
@@ -87,7 +87,8 @@ class PackageInfo {
 			// http://www.topline.tv/DO.html
 			'SOD-?(27|57|61|64|66|68|80|81|83|87|88|89|91|107|118|119|121|125)',
 			// SOD323 / http://www.nxp.com/packages/SOD323
-			'SOD-?(323|523)F?',
+			// SOD-123, SOD-323, SOD-523 and SOD-923 / https://en.wikipedia.org/wiki/Small_Outline_Diode
+			'SOD-?([1-9]23)-?(F|FL)?',
 			'SC-?(90|59A)',
 			'TO-?236AA',
 			//  Quad Flat No-leads package / https://en.wikipedia.org/wiki/Quad_Flat_No-leads_package#Variants / http://anysilicon.com/ultimate-guide-qfn-package/

--- a/tests/PackageInfoTest.php
+++ b/tests/PackageInfoTest.php
@@ -338,6 +338,8 @@ class PackageInfoTest extends TestCase {
 			[ 'MPS9805* TO202-1 NPN 65V 0.1A 0.5W =BC107', 'TO-202-1' ],
 			[ 'X0403DF ST 96+ TO202-3', 'TO-202-3' ],
 
+			// https://en.wikipedia.org/wiki/Small_Outline_Diode
+			[ 'Dioda prostownicza SMD standardowa 1000V 1A obudowa SOD-123FL', 'SOD123FL'],
 			[ '0603/SOD-523F', 'SOD523F' ],
 			[ '1005/SOD-323F', 'SOD323F' ],
 			[ 'SOD323F (SC-90)', 'SOD323F' ],


### PR DESCRIPTION
> Small Outline Diode (SOD) is a designation for a group of semiconductor packages for surface mounted diodes. The standard includes multiple variants such as SOD-123, SOD-323, SOD-523 and SOD-923. SOD-123 is the largest, SOD-923 is the smallest.
>
> -- https://en.wikipedia.org/wiki/Small_Outline_Diode